### PR TITLE
GH-11 add linting and formatting for better maintainability

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,19 @@
+name: Lint Codebase with Ruff
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  linter-for-suffering:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout GitHub Action"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+
+      - name: Lint with Ruff
+        uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1
+        with:
+          args: "check --config ruff.toml"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .logs
 .venv/
+.env
 __pycache__/
 work/
 project/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ loguru
 wget
 python-git-wrapper
 tqdm
+python-dotenv
+ruff

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,88 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 100
+indent-width = 4
+
+[lint]
+# Enable Linting Rules
+select = [
+    "E",   # pycodestyle Rules. See https://docs.astral.sh/ruff/rules/#perflint-perf
+    "F",   # Pyflakes Rules. See https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "PL",  # Pylint Rules. See https://docs.astral.sh/ruff/rules/#pylint-pl
+    "PD",  # Pandas-Vet Rules. See https://docs.astral.sh/ruff/rules/#pandas-vet-pd
+    "NPY", # Numpy Rules. See https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy
+]
+# Ignore specific rules
+ignore = [
+    "PLR0911", # Pylint: Too many return statements
+    "PLR0915", # Pylint: Too many statements in function
+    "PLR0913", # Pylint: Too many arguments
+    "PLR0912", # Pylint: Too many branches
+    "PLR2004", # Pylint: Consider using `isinstance` instead of `type`
+]
+
+# Exclude Jupyter notebooks from linting.
+exclude = ["*.ipynb"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/run.py
+++ b/run.py
@@ -1,23 +1,32 @@
 import os
 
-from common import *
+from common import Constants, logger, pre_init, download_server_jar, decompile
 import sys
 import shutil
 import xml.etree.ElementTree as ET
-
+import subprocess
+import tempfile
+from pathlib import Path
 from python_git_wrapper import Repository, GitError
+
+from dotenv import load_dotenv
+
+load_dotenv()
 
 USE_MAVEN = True
 
 
 def ensure_repo() -> Repository:
     if not Constants.PROJECT_DIR.is_dir() or not (Constants.PROJECT_DIR / ".git").is_dir():
-        logger.error("Project directory does not exist or is not a git repository. Please run setup first.")
+        logger.error(
+            "Project directory does not exist or is not a git repository. Please run setup first."
+        )
         sys.exit(1)
 
     repo = Repository(str(Constants.DECOMPILE_DIR))
     # repo.current_branch  # will raise if empty
     return repo
+
 
 def apply_feature_patches(repo: Repository):
     try:
@@ -66,7 +75,7 @@ def apply_source_patches():
         # Copy original to target, stripping CR
         target_file.parent.mkdir(parents=True, exist_ok=True)
 
-        content = original_file.read_bytes().replace(b'\r', b'')
+        content = original_file.read_bytes().replace(b"\r", b"")
         target_file.write_bytes(content)
 
         # Apply patch
@@ -74,14 +83,20 @@ def apply_source_patches():
             # Run from project root with --directory to handle paths correctly
             relative_src_path = src_root.relative_to(Constants.PROJECT_DIR)
             # Use forward slashes for git directory argument
-            directory_arg = str(relative_src_path).replace(os.sep, '/')
+            directory_arg = str(relative_src_path).replace(os.sep, "/")
 
             out = subprocess.run(
-                ["git", "apply", f"--directory={directory_arg}", "-p1", str(patch_file.absolute())],
+                [
+                    "git",
+                    "apply",
+                    f"--directory={directory_arg}",
+                    "-p1",
+                    str(patch_file.absolute()),
+                ],
                 cwd=str(Constants.PROJECT_DIR),
                 check=True,
                 capture_output=True,
-                text=True
+                text=True,
             )
             logger.info("Applied patch {}, out={}", rel_path, out.stdout.strip())
         except subprocess.CalledProcessError as e:
@@ -116,14 +131,20 @@ def make_source_patches():
             t_orig.parent.mkdir(parents=True, exist_ok=True)
             t_mod.parent.mkdir(parents=True, exist_ok=True)
 
-            t_orig.write_bytes(original_file.read_bytes().replace(b'\r', b''))
-            t_mod.write_bytes(file_path.read_bytes().replace(b'\r', b''))
+            t_orig.write_bytes(original_file.read_bytes().replace(b"\r", b""))
+            t_mod.write_bytes(file_path.read_bytes().replace(b"\r", b""))
 
-            cmd = ["git", "diff", "--no-index", "--minimal", "--no-prefix",
-                   f"a/{rel_path.as_posix()}",
-                   f"b/{rel_path.as_posix()}"]
+            cmd = [
+                "git",
+                "diff",
+                "--no-index",
+                "--minimal",
+                "--no-prefix",
+                f"a/{rel_path.as_posix()}",
+                f"b/{rel_path.as_posix()}",
+            ]
 
-            result = subprocess.run(cmd, cwd=tmpdir, capture_output=True, text=True)
+            result = subprocess.run(cmd, cwd=tmpdir, capture_output=True, text=True, check=True)
 
             patch_content = result.stdout
             patch_file = patches_root / rel_path.with_suffix(".patch")
@@ -136,10 +157,9 @@ def make_source_patches():
                     patch_file.write_text(patch_content)
                     logger.info("Created/Updated patch: {}", patch_file.name)
                     count += 1
-            else:
-                if patch_file.exists():
-                    patch_file.unlink()
-                    logger.info("Removed patch: {}", patch_file.name)
+            elif patch_file.exists():
+                patch_file.unlink()
+                logger.info("Removed patch: {}", patch_file.name)
 
     logger.info("Processed source patches. Created/Updated: {}", count)
 
@@ -148,18 +168,19 @@ if __name__ == "__main__":
     actions = ("setup", "makeFeaturePatches", "makeSourcePatches", "applySourcePatches")
 
     if len(sys.argv) <= 1 or sys.argv[1] not in actions:
-        print("Usage: python run.py [{}]".format("|".join(actions)))
+        logger.info("Usage: python run.py [{}]".format("|".join(actions)))
         sys.exit(1)
 
-    logger.info('\n\n[ [ HytaleModding patcher by Neil, ribica & other contributors ] ]\n')
-
+    logger.info("\n\n[ [ HytaleModding patcher by Neil, ribica & other contributors ] ]\n")
 
     action = sys.argv[1]
     pre_init()
 
     if action == "setup":
         if Constants.PROJECT_DIR.is_dir():
-            logger.warning("Project directory already exists. Please delete the folder and run setup again.")
+            logger.warning(
+                "Project directory already exists. Please delete the folder and run setup again."
+            )
             sys.exit(1)
 
         decompile_dir = Constants.DECOMPILE_DIR
@@ -187,23 +208,32 @@ if __name__ == "__main__":
             # src.mkdir(parents=True, exist_ok=True)
         else:
             # Maven initialization:
-            # mvn archetype:generate -DgroupId=com.hypixel.hytale -DartifactId=hytale-server -DarchetypeArtifactId=maven‑archetype‑quickstart -DinteractiveMode=false
+            # mvn archetype:generate -DgroupId=com.hypixel.hytale -DartifactId=hytale-server -DarchetypeArtifactId=maven‑archetype‑quickstart -DinteractiveMode=false  # noqa: E501
             logger.info("\n\nInitializing Maven project in:\n{}\n\n", Constants.PROJECT_DIR)
 
             # Use shell if on windows else do not see:
             # https://github.com/HytaleModding/patcher/issues/5
             # https://github.com/HytaleModding/patcher/issues/9
-            use_shell = os.name == 'nt'
+            use_shell = os.name == "nt"
 
             logger.warning("Using shell={} for mvn command because of your OS.", use_shell)
-            logger.warning("IF MAVEN COMMAND FAILS, PLEASE TRY THE OTHER OPTION BY EDITING run.py manually")
+            logger.warning(
+                "IF MAVEN COMMAND FAILS, PLEASE TRY THE OTHER OPTION BY EDITING run.py manually"
+            )
 
-            subprocess.run([
-                "mvn", "archetype:generate",
-                # "-DgroupId=com.hypixel.hytale", "-DartifactId=hytale-server",
-                "-DgroupId=com.hypixel.hytale", "-DartifactId=" + Constants.PROJECT_DIR.name,
-                "-DarchetypeArtifactId=maven-archetype-quickstart", "-DinteractiveMode=false"
-            ], check=True, shell=use_shell)
+            subprocess.run(
+                [
+                    "mvn",
+                    "archetype:generate",
+                    # "-DgroupId=com.hypixel.hytale", "-DartifactId=hytale-server",
+                    "-DgroupId=com.hypixel.hytale",
+                    "-DartifactId=" + Constants.PROJECT_DIR.name,
+                    "-DarchetypeArtifactId=maven-archetype-quickstart",
+                    "-DinteractiveMode=false",
+                ],
+                check=True,
+                shell=use_shell,
+            )
 
             logger.info("Maven project initialized!")
 
@@ -212,8 +242,8 @@ if __name__ == "__main__":
             template_file = Constants.BASE_DIR / "pom.xml.template"
 
             if template_file.exists():
-                ET.register_namespace('', "http://maven.apache.org/POM/4.0.0")
-                ns = {'mvn': 'http://maven.apache.org/POM/4.0.0'}
+                ET.register_namespace("", "http://maven.apache.org/POM/4.0.0")
+                ns = {"mvn": "http://maven.apache.org/POM/4.0.0"}
 
                 target_tree = ET.parse(pom_file)
                 target_root = target_tree.getroot()
@@ -222,23 +252,25 @@ if __name__ == "__main__":
                 template_root = template_tree.getroot()
 
                 # Update dependencies
-                tmpl_deps = template_root.find('mvn:dependencies', ns)
+                tmpl_deps = template_root.find("mvn:dependencies", ns)
                 if tmpl_deps is not None:
-                    target_deps = target_root.find('mvn:dependencies', ns)
+                    target_deps = target_root.find("mvn:dependencies", ns)
                     if target_deps is not None:
                         target_root.remove(target_deps)
                     target_root.append(tmpl_deps)
 
                 # Update build
-                tmpl_build = template_root.find('mvn:build', ns)
+                tmpl_build = template_root.find("mvn:build", ns)
                 if tmpl_build is not None:
-                    target_build = target_root.find('mvn:build', ns)
+                    target_build = target_root.find("mvn:build", ns)
                     if target_build is not None:
                         target_root.remove(target_build)
                     target_root.append(tmpl_build)
 
-                target_tree.write(pom_file, encoding='UTF-8', xml_declaration=True)
-                logger.info("Updated pom.xml with dependencies and build configuration from template")
+                target_tree.write(pom_file, encoding="UTF-8", xml_declaration=True)
+                logger.info(
+                    "Updated pom.xml with dependencies and build configuration from template"
+                )
             else:
                 logger.warning("pom.xml.template not found, skipping pom update")
 
@@ -262,7 +294,7 @@ if __name__ == "__main__":
 
         repo = Repository(str(Constants.PROJECT_DIR))
         repo.execute("init")
-        repo.add_files(['.gitignore'])
+        repo.add_files([".gitignore"])
         repo.add_files(all_files=True)
         repo.commit("Initial decompilation")
         repo.execute("tag baseline")
@@ -270,12 +302,16 @@ if __name__ == "__main__":
         # logger.info("Applying patches")
         # apply_feature_patches(repo)
 
-        logger.info('')
-        logger.info('Setup finished!')
-        logger.info('You can now open the "{}" folder in IntelliJ IDEA and follow further instructions in the README', Constants.PROJECT_DIR)
-        logger.info('Please give us a star on GitHub if you find this project useful.')
-        logger.info('Happy Modding!')
-        logger.info('')
+        logger.info("")
+        logger.info("Setup finished!")
+        logger.info(
+            'You can now open the "{}" folder in IntelliJ IDEA and follow further '
+            "instructions in the README",
+            Constants.PROJECT_DIR,
+        )
+        logger.info("Please give us a star on GitHub if you find this project useful.")
+        logger.info("Happy Modding!")
+        logger.info("")
 
     elif action == "makeFeaturePatches":
         logger.warning("This is deprecated, please consider using makeSourcePatches instead.")
@@ -286,7 +322,8 @@ if __name__ == "__main__":
         # git format-patch --no-stat --minimal -N -o ../patches [range]
         # range can be abc1234..HEAD or similar
 
-        # for some reason this does not work, like python subprocess changes how baseline..HEAD is passed as argument?
+        # for some reason this does not work,
+        # like python subprocess changes how baseline..HEAD is passed as argument?
         # out = repo.execute(
         #     "format-patch --no-stat --minimal -N",
         #     "-o", tmp.name,
@@ -294,7 +331,11 @@ if __name__ == "__main__":
         # )
         out = subprocess.run(
             f'git format-patch --no-stat --minimal -N -o "{tmp.name}" baseline..HEAD',
-            cwd=str(Constants.PROJECT_DIR), shell=True, capture_output=True, text=True, check=True
+            cwd=str(Constants.PROJECT_DIR),
+            shell=True,
+            capture_output=True,
+            text=True,
+            check=True,
         )
 
         logger.info("git format-patch output:\n{}", out.stdout.strip())
@@ -306,7 +347,7 @@ if __name__ == "__main__":
                 continue  # skip existing patches
             shutil.move(
                 os.path.join(tmp.name, new_patch_file),
-                Constants.PATCHES_DIR / new_patch_file
+                Constants.PATCHES_DIR / new_patch_file,
             )
             copies += 1
 

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,6 @@
-import tempfile, sys, subprocess
+import tempfile
+import sys
+import subprocess
 from loguru import logger
 from pathlib import Path
 
@@ -9,15 +11,19 @@ def ensure_java():
         fp = tempfile.TemporaryDirectory()
         fpath = Path(fp.name) / "A.java"
         fpath.write_bytes(
-            b"public class A{ public static void main(String[] a) { System.out.println(System.getProperty(\"java.version\")); }}")
-        result = subprocess.run(["java", str(fpath)], capture_output=True, text=True, check=True)  # java 11+
+            b'public class A{ public static void main(String[] a) { System.out.println(System.getProperty("java.version")); }}'  # noqa: E501
+        )
+        result = subprocess.run(
+            ["java", str(fpath)], capture_output=True, text=True, check=True
+        )  # java 11+
         java_version = result.stdout.strip()
         fp.cleanup()
     except (FileNotFoundError, subprocess.CalledProcessError):
         logger.error(
-            "Java not found or outdated! Please make sure JDK 25 is installed and available in your system PATH.")
+            "Java not found or outdated!"
+            " Please make sure JDK 25 is installed and available in your system PATH."
+        )
         sys.exit(1)
-
 
     major = 0
     if java_version is not None:
@@ -29,15 +35,15 @@ def ensure_java():
 
     logger.info("Java check success: {}", java_version)
 
-    return java_version
-
 
 def ensure_git():
     try:
         _ = subprocess.run(["git", "--version"], capture_output=True, text=True, check=True)
         logger.info("Git check success: {}", _.stdout.strip())
     except (FileNotFoundError, subprocess.CalledProcessError):
-        logger.error("Git not found! Please make sure Git is installed and available in your system PATH.")
+        logger.error(
+            "Git not found! Please make sure Git is installed and available in your system PATH."
+        )
         sys.exit(1)
 
 
@@ -46,5 +52,8 @@ def ensure_jar():
         _ = subprocess.run(["jar", "--version"], capture_output=True, text=True, check=True)
         logger.info("Jar utility check success: {}", _.stdout.strip())
     except (FileNotFoundError, subprocess.CalledProcessError):
-        logger.error("Please make sure JDK is properly installed and the corresponding bin folder is on PATH.")
+        logger.error(
+            "Please make sure JDK is properly installed "
+            "and the corresponding bin folder is on PATH."
+        )
         sys.exit(1)


### PR DESCRIPTION
# Description
This PR implements Ruff as a linting and formatting tool to maintain a clean codebase for easier maintainability and contribution. The following Linting Rules are applied:
- "E",   # pycodestyle Rules. See https://docs.astral.sh/ruff/rules/#perflint-perf
- "F",   # Pyflakes Rules. See https://docs.astral.sh/ruff/rules/#pyflakes-f
- "PL",  # Pylint Rules. See https://docs.astral.sh/ruff/rules/#pylint-pl
- "PD",  # Pandas-Vet Rules. See https://docs.astral.sh/ruff/rules/#pandas-vet-pd
- "NPY", # Numpy Rules. See https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy

Additionally a Workflow was added for CI/CD linting on Pull Requests and Pushes on Main.

> P.S: I also added load_dotenv to support reading `.env` files when users want to use the ENV variable for the hytale server jar file. I hope this is ok, if this is not in its own PR, since it is only 2 lines

---

fixes:
Closes #11 
 gh-11
